### PR TITLE
Prevent <head> from being interpreted as HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See it in action [here](http://fikascript.se).
 ### Including FikaScript files in your HTML
 
 - Include [fikascript.js](dist/fikascript.js) and [fikascript.browser.js](dist/fikascript.browser.js).
-- Make sure your html is set to allow utf-8 characters (add `<meta charset="utf-8">` in the <head>).
+- Make sure your html is set to allow utf-8 characters (add `<meta charset="utf-8">` in the `<head>`).
 
 FikaScript supports the `text/fikascript` MIME type. Any script tag with that type will be compiled and run automatically:
 ```html


### PR DESCRIPTION
This causes it to be hidden in the rendered README.